### PR TITLE
fix: correctifs suite retour

### DIFF
--- a/FTTHMUTTroubleTicketValue-v3-0.xsd
+++ b/FTTHMUTTroubleTicketValue-v3-0.xsd
@@ -19,7 +19,7 @@
 		</xsd:simpleType>
 		<xsd:simpleType name="serviceProviderName">
 			<xsd:restriction base="xsd:string">
-				<xsd:minLength value="1"/>
+				<xsd:minLength value=""/>
 				<xsd:maxLength value="40"/>
 			</xsd:restriction>
 		</xsd:simpleType>
@@ -43,7 +43,7 @@
 		</xsd:simpleType>
 		<xsd:simpleType name="supplierName">
 			<xsd:restriction base="xsd:string">
-				<xsd:minLength value="1"/>
+				<xsd:minLength value=""/>
 				<xsd:maxLength value="40"/>
 			</xsd:restriction>
 		</xsd:simpleType>
@@ -74,13 +74,13 @@
 		</xsd:simpleType>
 		<xsd:simpleType name="commercialId">
 			<xsd:restriction base="xsd:string">
-				<xsd:minLength value="1"/>
+				<xsd:minLength value="0"/>
 				<xsd:maxLength value="50"/>
 			</xsd:restriction>
 		</xsd:simpleType>
 		<xsd:simpleType name="technicalId">
 			<xsd:restriction base="xsd:string">
-				<xsd:minLength value="1"/>
+				<xsd:minLength value="0"/>
 				<xsd:maxLength value="50"/>
 			</xsd:restriction>
 		</xsd:simpleType>


### PR DESCRIPTION
- correctifs longueur minimales des champs serviceProviderName,
supplierName, commercialId et technicalId